### PR TITLE
fix(middleware): pass through unauthenticated requests

### DIFF
--- a/src/Http/Middleware/LogApiRequest.php
+++ b/src/Http/Middleware/LogApiRequest.php
@@ -16,11 +16,9 @@ class LogApiRequest
      */
     public function handle(Request $request, Closure $next)
     {
-        if (! auth()->check()) {
-            return;
+        if (auth()->check()) {
+            $request->start = microtime(true);
         }
-
-        $request->start = microtime(true);
 
         return $next($request);
     }

--- a/src/Http/Middleware/LogApiRequest.php
+++ b/src/Http/Middleware/LogApiRequest.php
@@ -16,9 +16,7 @@ class LogApiRequest
      */
     public function handle(Request $request, Closure $next)
     {
-        if (auth()->check()) {
-            $request->start = microtime(true);
-        }
+        $request->start = microtime(true);
 
         return $next($request);
     }


### PR DESCRIPTION
### Description

`LogApiRequest::handle()` short-circuited with a bare `return;` for unauthenticated requests, sending a null response on any public route behind the middleware. Unauthenticated requests now pass through the pipeline normally and are simply not logged.

### Fixes

This fixes #7.