### PR TITLE
feat: add support for laravel 11, 12 and 13

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+* text=auto
+*.php text eol=lf
+*.stub text eol=lf
+*.md text eol=lf
+*.json text eol=lf
+*.yml text eol=lf
+
+/tests export-ignore
+/.github export-ignore
+/phpunit.xml export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,48 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.2', '8.3', '8.4']
+        laravel: ['11.*', '12.*', '13.*']
+        include:
+          - laravel: '11.*'
+            testbench: '9.*'
+          - laravel: '12.*'
+            testbench: '10.*'
+          - laravel: '13.*'
+            testbench: '11.*'
+        exclude:
+          - laravel: '13.*'
+            php: '8.2'
+
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mbstring, pdo, sqlite3, pdo_sqlite
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          composer require "illuminate/database:${{ matrix.laravel }}" "illuminate/support:${{ matrix.laravel }}" --no-interaction --no-update
+          composer require --dev "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --prefer-dist --no-interaction
+
+      - name: Run tests
+        run: vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /.idea
+/vendor
+/.phpunit.cache
+composer.lock

--- a/README.md
+++ b/README.md
@@ -3,7 +3,15 @@
 A lightweight Laravel package for logging requests made to your API.
 
 [![Latest version](https://img.shields.io/github/release/CodeTechAgency/laravel-api-logs?style=flat-square)](https://github.com/CodeTechAgency/laravel-api-logs/releases)
-[![GitHub license](https://img.shields.io/github/license/CodeTechAgency/laravel-api-logs?style=flat-square)](https://github.com/CodeTechAgency/laravel-api-logs/blob/master/LICENSE)
+[![Tests](https://img.shields.io/github/actions/workflow/status/CodeTechAgency/laravel-api-logs/tests.yml?style=flat-square&label=tests)](https://github.com/CodeTechAgency/laravel-api-logs/actions/workflows/tests.yml)
+[![GitHub license](https://img.shields.io/github/license/CodeTechAgency/laravel-api-logs?style=flat-square)](https://github.com/CodeTechAgency/laravel-api-logs/blob/main/LICENSE)
+
+## Requirements
+
+| Package version | Laravel    | PHP  |
+|-----------------|------------|------|
+| 3.x             | 11 / 12 / 13 | ≥ 8.2 |
+| 2.x             | 7 – 10     | ≥ 7.2 |
 
 ## Installation
 
@@ -13,19 +21,7 @@ Add the package to your Laravel application using composer:
 composer require codetech/laravel-api-logs
 ```
 
-
-### Service Provider
-
-The service provider will be automatically registered during the installation process. However, you can manually register it by adding it to the list of providers located in your `config/app.php` file:
-
-```
-'providers' => [
-    ...
-    Codetech\ApiLogs\Providers\ApiLogServiceProvider::class,
-
-],
-```
-
+The service provider is registered automatically via package discovery.
 
 ### Migrations
 
@@ -36,36 +32,57 @@ php artisan vendor:publish --provider=CodeTech\\ApiLogs\\Providers\\ApiLogServic
 ```
 
 Run the migration:
+
 ```
 php artisan migrate
 ```
 
 ## Usage
 
-To start logging requests made to your API, you simply add the middleware to the API's route middleware group, located in your `app/Http/Kernel.php`:
+Add the `HasApiLogs` trait to the model that makes the requests (typically your `User` model):
 
+```php
+use CodeTech\ApiLogs\Traits\HasApiLogs;
+
+class User extends Authenticatable
+{
+    use HasApiLogs;
+}
 ```
+
+To start logging requests made to your API, append the middleware to the `api` middleware group in your `bootstrap/app.php`:
+
+```php
 use CodeTech\ApiLogs\Http\Middleware\LogApiRequest;
+use Illuminate\Foundation\Configuration\Middleware;
 
-
-protected $middlewareGroups = [
-    ...
-
-    'api' => [
-        ...
-        LogApiRequest::class,
-    ],
-];
+return Application::configure(basePath: dirname(__DIR__))
+    // ...
+    ->withMiddleware(function (Middleware $middleware) {
+        $middleware->appendToGroup('api', LogApiRequest::class);
+    })
+    // ...
+    ->create();
 ```
 
+Only authenticated requests are logged. Each log stores the URL, HTTP method, client IP, request data, request headers, response data and the request duration, and is linked to the authenticated user through a polymorphic `causer` relation:
+
+```php
+$user->apiLogs; // all ApiLog entries for the user
+$apiLog->causer; // the model that made the request
+```
+
+## Testing
+
+```
+composer test
+```
 
 ---
 
-
 ## License
 
-**codetech/laravel-api-logs** is open-sourced software licensed under the [MIT license](https://github.com/CodeTechAgency/laravel-api-logs/blob/master/LICENSE).
-
+**codetech/laravel-api-logs** is open-sourced software licensed under the [MIT license](https://github.com/CodeTechAgency/laravel-api-logs/blob/main/LICENSE).
 
 ## About CodeTech
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ A lightweight Laravel package for logging requests made to your API.
 | 3.x             | 11 / 12 / 13 | ≥ 8.2 |
 | 2.x             | 7 – 10     | ≥ 7.2 |
 
+Upgrading from 2.x? See the [upgrade guide](UPGRADE.md).
+
 ## Installation
 
 Add the package to your Laravel application using composer:

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,74 @@
+# Upgrade Guide
+
+## Upgrading from 2.x to 3.0
+
+### New requirements
+
+| | 2.x | 3.x |
+|---|---|---|
+| PHP | ≥ 7.2 | ≥ 8.2 (≥ 8.3 for Laravel 13) |
+| Laravel | 7 – 10 | 11 / 12 / 13 |
+
+Update your `composer.json`:
+
+```json
+"codetech/laravel-api-logs": "^3.0"
+```
+
+If your application is still on Laravel 10 or older, stay on `^2.0` — v2.0.2 is the latest 2.x release.
+
+### Middleware registration has moved
+
+Laravel 11 removed `app/Http/Kernel.php`. Register the middleware in `bootstrap/app.php` instead:
+
+```php
+use CodeTech\ApiLogs\Http\Middleware\LogApiRequest;
+use Illuminate\Foundation\Configuration\Middleware;
+
+return Application::configure(basePath: dirname(__DIR__))
+    // ...
+    ->withMiddleware(function (Middleware $middleware) {
+        $middleware->appendToGroup('api', LogApiRequest::class);
+    })
+    // ...
+    ->create();
+```
+
+### Request timing is no longer stored in dynamic properties
+
+The middleware previously wrote `$request->start` and `$request->end` directly on the `Request` object (a dynamic property, deprecated since PHP 8.2). The start time now lives in the request attribute bag:
+
+```php
+$request->attributes->get('api_logs.start');
+```
+
+If your code read `$request->start` or `$request->end`, update it accordingly (`end` has no replacement — it was only ever the log's write time; use the `duration` column of the log instead).
+
+### Stricter middleware signatures
+
+`handle()` now declares a `Symfony\Component\HttpFoundation\Response` return type and `terminate()` type-hints its `$response` parameter. If you extended `LogApiRequest`, update your overrides to match.
+
+### Users without the `HasApiLogs` trait are skipped
+
+`terminate()` now verifies that the authenticated model actually has an `apiLogs()` method before logging. In 2.x an authenticated model without the trait caused a fatal error; in 3.x the request is silently not logged. Make sure your user model uses the trait if you expect its requests to be logged:
+
+```php
+use CodeTech\ApiLogs\Traits\HasApiLogs;
+
+class User extends Authenticatable
+{
+    use HasApiLogs;
+}
+```
+
+### `ApiLog` casts moved to the `casts()` method
+
+The `$casts` property was replaced by the Laravel 11+ `casts()` method. If you extended `CodeTech\ApiLogs\Models\ApiLog` and defined your own `$casts`, Laravel merges both, but review the result to be sure it's what you expect.
+
+### Non-JSON responses
+
+`response_data` is now stored as `null` for responses without string content (e.g. streamed or binary file responses) instead of attempting to decode them.
+
+### No database changes
+
+The `api_logs` table schema is unchanged — no new migration is required. (The published migration stub is now an anonymous class, which only affects migrations published after the upgrade.)

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,26 @@
   ],
   "license": "MIT",
   "require": {
-    "php": "^7.2|^8.0",
-    "illuminate/database": "^7.0|^8.0|^9.0|^10.0",
-    "illuminate/support": "^7.0|^8.0|^9.0|^10.0"
+    "php": "^8.2",
+    "illuminate/database": "^11.0|^12.0|^13.0",
+    "illuminate/support": "^11.0|^12.0|^13.0"
+  },
+  "require-dev": {
+    "orchestra/testbench": "^9.0|^10.0|^11.0",
+    "phpunit/phpunit": "^10.5|^11.0|^12.0"
   },
   "autoload": {
     "psr-4": {
       "CodeTech\\ApiLogs\\": "src/"
     }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "CodeTech\\ApiLogs\\Tests\\": "tests/"
+    }
+  },
+  "scripts": {
+    "test": "phpunit"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/database/migrations/create_api_logs_table.php.stub
+++ b/database/migrations/create_api_logs_table.php.stub
@@ -4,14 +4,12 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateApiLogsTable extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
-     *
-     * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('api_logs', function (Blueprint $table) {
             $table->id();
@@ -29,11 +27,9 @@ class CreateApiLogsTable extends Migration
 
     /**
      * Reverse the migrations.
-     *
-     * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists('api_logs');
     }
-}
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="Package">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Http/Middleware/LogApiRequest.php
+++ b/src/Http/Middleware/LogApiRequest.php
@@ -4,46 +4,45 @@ namespace CodeTech\ApiLogs\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class LogApiRequest
 {
     /**
      * Handle an incoming request.
-     *
-     * @param  Request  $request
-     * @param  Closure  $next
-     * @return mixed
      */
-    public function handle(Request $request, Closure $next)
+    public function handle(Request $request, Closure $next): Response
     {
-        $request->start = microtime(true);
+        $request->attributes->set('api_logs.start', microtime(true));
 
         return $next($request);
     }
 
     /**
      * Handle tasks after the response has been sent to the browser.
-     *
-     * @param  Request  $request
-     * @param $response
-     * @return void
      */
-    public function terminate(Request $request, $response): void
+    public function terminate(Request $request, Response $response): void
     {
-        if (! auth()->check()) {
+        $user = auth()->user();
+
+        if ($user === null || ! method_exists($user, 'apiLogs')) {
             return;
         }
 
-        $request->end = microtime(true);
+        $start = $request->attributes->get('api_logs.start')
+            ?? $request->server('REQUEST_TIME_FLOAT')
+            ?? microtime(true);
 
-        auth()->user()->apiLogs()->create([
-            'duration' => $request->end - $request->start,
+        $content = $response->getContent();
+
+        $user->apiLogs()->create([
+            'duration' => microtime(true) - $start,
             'url' => $request->fullUrl(),
             'method' => $request->getMethod(),
             'ip' => $request->getClientIp(),
             'request_data' => $request->all(),
             'request_headers' => $request->headers->all(),
-            'response_data' => json_decode($response->getContent()),
+            'response_data' => is_string($content) ? json_decode($content) : null,
         ]);
     }
 }

--- a/src/Models/ApiLog.php
+++ b/src/Models/ApiLog.php
@@ -3,6 +3,7 @@
 namespace CodeTech\ApiLogs\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
 
 class ApiLog extends Model
 {
@@ -20,18 +21,22 @@ class ApiLog extends Model
     ];
 
     /**
-     * @inheritdoc
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
      */
-    protected $casts = [
-        'request_data' => 'json',
-        'request_headers' => 'json',
-        'response_data' => 'json',
-        'created_at' => 'datetime:d/m/Y H:i',
-        'updated_at' => 'datetime:d/m/Y H:i',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'request_data' => 'json',
+            'request_headers' => 'json',
+            'response_data' => 'json',
+            'created_at' => 'datetime:d/m/Y H:i',
+            'updated_at' => 'datetime:d/m/Y H:i',
+        ];
+    }
 
-
-    public function causer()
+    public function causer(): MorphTo
     {
         return $this->morphTo();
     }

--- a/src/Providers/ApiLogServiceProvider.php
+++ b/src/Providers/ApiLogServiceProvider.php
@@ -8,20 +8,16 @@ class ApiLogServiceProvider extends ServiceProvider
 {
     /**
      * Register services.
-     *
-     * @return void
      */
-    public function register()
+    public function register(): void
     {
         //
     }
 
     /**
      * Bootstrap any application services.
-     *
-     * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         $this->setPublishableFiles();
     }
@@ -29,12 +25,12 @@ class ApiLogServiceProvider extends ServiceProvider
     /**
      * Sets the publishable files.
      */
-    private function setPublishableFiles()
+    private function setPublishableFiles(): void
     {
-        $databasePath = sprintf('migrations/%s_create_api_logs_table.php', date('Y_m_d_His', time()));
+        $databasePath = sprintf('migrations/%s_create_api_logs_table.php', date('Y_m_d_His'));
 
         $this->publishes([
-            __DIR__.'/../../database/migrations/create_api_logs_table.php.stub' => database_path($databasePath)
+            __DIR__.'/../../database/migrations/create_api_logs_table.php.stub' => database_path($databasePath),
         ], 'migrations');
     }
 }

--- a/tests/Fixtures/User.php
+++ b/tests/Fixtures/User.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace CodeTech\ApiLogs\Tests\Fixtures;
+
+use CodeTech\ApiLogs\Traits\HasApiLogs;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+
+class User extends Authenticatable
+{
+    use HasApiLogs;
+
+    protected $guarded = [];
+}

--- a/tests/HasApiLogsTest.php
+++ b/tests/HasApiLogsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace CodeTech\ApiLogs\Tests;
+
+use CodeTech\ApiLogs\Models\ApiLog;
+use CodeTech\ApiLogs\Tests\Fixtures\User;
+
+class HasApiLogsTest extends TestCase
+{
+    public function test_api_logs_morph_relation_round_trips(): void
+    {
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'user@example.com',
+            'password' => 'secret',
+        ]);
+
+        $log = $user->apiLogs()->create([
+            'duration' => 0.123,
+            'url' => 'https://example.com/api/ping',
+            'method' => 'GET',
+            'ip' => '127.0.0.1',
+            'request_data' => ['foo' => 'bar'],
+            'request_headers' => ['accept' => ['application/json']],
+            'response_data' => ['pong' => true],
+        ]);
+
+        $this->assertSame(1, $user->apiLogs()->count());
+        $this->assertTrue(ApiLog::first()->causer->is($user));
+        $this->assertSame(['foo' => 'bar'], $log->fresh()->request_data);
+    }
+}

--- a/tests/LogApiRequestMiddlewareTest.php
+++ b/tests/LogApiRequestMiddlewareTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace CodeTech\ApiLogs\Tests;
+
+use CodeTech\ApiLogs\Http\Middleware\LogApiRequest;
+use CodeTech\ApiLogs\Models\ApiLog;
+use CodeTech\ApiLogs\Tests\Fixtures\User;
+
+class LogApiRequestMiddlewareTest extends TestCase
+{
+    protected function defineRoutes($router): void
+    {
+        $router->middleware(LogApiRequest::class)->group(function () use ($router) {
+            $router->get('/api/ping', fn () => response()->json(['pong' => true]));
+            $router->post('/api/echo', fn () => response()->json(['ok' => true]));
+        });
+    }
+
+    public function test_authenticated_request_is_logged(): void
+    {
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'user@example.com',
+            'password' => 'secret',
+        ]);
+
+        $this->actingAs($user)
+            ->postJson('/api/echo?foo=bar', ['name' => 'value'])
+            ->assertOk();
+
+        $this->assertSame(1, ApiLog::count());
+
+        $log = ApiLog::first();
+        $this->assertSame('POST', $log->method);
+        $this->assertStringContainsString('/api/echo', $log->url);
+        $this->assertNotEmpty($log->ip);
+        $this->assertGreaterThan(0, $log->duration);
+        $this->assertEquals(['foo' => 'bar', 'name' => 'value'], $log->request_data);
+        $this->assertSame(['ok' => true], (array) $log->response_data);
+        $this->assertArrayHasKey('host', $log->request_headers);
+        $this->assertTrue($log->causer->is($user));
+    }
+
+    public function test_unauthenticated_request_passes_through_and_is_not_logged(): void
+    {
+        $this->getJson('/api/ping')
+            ->assertOk()
+            ->assertJson(['pong' => true]);
+
+        $this->assertSame(0, ApiLog::count());
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace CodeTech\ApiLogs\Tests;
+
+use CodeTech\ApiLogs\Providers\ApiLogServiceProvider;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Orchestra\Testbench\TestCase as Orchestra;
+
+abstract class TestCase extends Orchestra
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->runMigrations();
+    }
+
+    protected function getPackageProviders($app): array
+    {
+        return [
+            ApiLogServiceProvider::class,
+        ];
+    }
+
+    protected function defineEnvironment($app): void
+    {
+        $app['config']->set('database.default', 'testing');
+    }
+
+    private function runMigrations(): void
+    {
+        $migration = require __DIR__.'/../database/migrations/create_api_logs_table.php.stub';
+        $migration->up();
+
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->timestamps();
+        });
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -26,6 +26,11 @@ abstract class TestCase extends Orchestra
     protected function defineEnvironment($app): void
     {
         $app['config']->set('database.default', 'testing');
+        $app['config']->set('database.connections.testing', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
     }
 
     private function runMigrations(): void


### PR DESCRIPTION
### Description

Modernizes the package for Laravel 11/12/13 (drops Laravel 7–10; new major version):

- `composer.json`: PHP `^8.2`, illuminate `^11.0|^12.0|^13.0`, Testbench + PHPUnit dev deps
- Migration stub converted to an anonymous class
- Middleware: typed signatures, timing stored in request attributes instead of dynamic properties (deprecated since PHP 8.2), `terminate()` guards against user models without `apiLogs()`, safe handling of non-string response content
- Model: `casts()` method, typed `causer(): MorphTo`
- New Testbench test suite (3 tests, incl. regression test for #7) and GitHub Actions matrix: PHP 8.2/8.3/8.4 × Laravel 11/12/13
- README rewritten for `bootstrap/app.php` middleware registration, requirements table
- `.gitattributes` for line-ending normalization + dist excludes

Stacked on #9 — merge that first; this PR is based on `fix-7` so it only shows the modernization diff.

### Fixes

This fixes #8.