### PR TITLE
feat(redaction): redact sensitive fields from logged requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,30 @@ $user->apiLogs; // all ApiLog entries for the user
 $apiLog->causer; // the model that made the request
 ```
 
+## Configuration
+
+Sensitive values are **redacted by default** before a log is stored: common credential fields (`password`, `token`, `access_token`, …) in the request data, query string and response data, and sensitive request headers (`Authorization`, `Cookie`, `X-Api-Key`, …) are replaced with `[REDACTED]`.
+
+To customize the redaction lists or the replacement string, publish the config file:
+
+```
+php artisan vendor:publish --provider=CodeTech\\ApiLogs\\Providers\\ApiLogServiceProvider --tag=config
+```
+
+Then adjust `config/api-logs.php`:
+
+```php
+return [
+    'redact' => [
+        'replacement' => '[REDACTED]',
+        'keys' => ['password', 'access_token' /* , ... */],
+        'headers' => ['authorization', 'cookie' /* , ... */],
+    ],
+];
+```
+
+`keys` are matched case-insensitively and recursively against the request payload, query string and response data; `headers` are matched against request header names.
+
 ## Testing
 
 ```

--- a/config/api-logs.php
+++ b/config/api-logs.php
@@ -1,0 +1,51 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Redaction
+    |--------------------------------------------------------------------------
+    |
+    | Sensitive values are replaced with the string below before the log is
+    | stored. "keys" are matched recursively (case-insensitively) against the
+    | request and response data; "headers" are matched against the request
+    | header names.
+    |
+    */
+
+    'redact' => [
+
+        'replacement' => '[REDACTED]',
+
+        'keys' => [
+            'password',
+            'password_confirmation',
+            'current_password',
+            'new_password',
+            'secret',
+            'token',
+            'api_token',
+            'access_token',
+            'refresh_token',
+            'private_key',
+            'credit_card',
+            'card_number',
+            'cvv',
+        ],
+
+        'headers' => [
+            'authorization',
+            'proxy-authorization',
+            'cookie',
+            'x-api-key',
+            'x-csrf-token',
+            'x-xsrf-token',
+            'php-auth-user',
+            'php-auth-pw',
+            'php-auth-digest',
+        ],
+
+    ],
+
+];

--- a/src/Http/Middleware/LogApiRequest.php
+++ b/src/Http/Middleware/LogApiRequest.php
@@ -50,7 +50,7 @@ class LogApiRequest
             'method' => $request->getMethod(),
             'ip' => $request->getClientIp(),
             'request_data' => Redactor::redact($request->all(), $keys, $replacement),
-            'request_headers' => Redactor::redact($request->headers->all(), $headers, $replacement),
+            'request_headers' => Redactor::redactHeaders($request->headers->all(), $headers, $replacement),
             'response_data' => is_array($responseData) ? Redactor::redact($responseData, $keys, $replacement) : $responseData,
         ]);
     }

--- a/src/Http/Middleware/LogApiRequest.php
+++ b/src/Http/Middleware/LogApiRequest.php
@@ -3,7 +3,9 @@
 namespace CodeTech\ApiLogs\Http\Middleware;
 
 use Closure;
+use CodeTech\ApiLogs\Support\Redactor;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Symfony\Component\HttpFoundation\Response;
 
 class LogApiRequest
@@ -34,15 +36,22 @@ class LogApiRequest
             ?? microtime(true);
 
         $content = $response->getContent();
+        $responseData = is_string($content) ? json_decode($content, true) : null;
+
+        $keys = config('api-logs.redact.keys', []);
+        $headers = config('api-logs.redact.headers', []);
+        $replacement = config('api-logs.redact.replacement', '[REDACTED]');
+
+        $query = Redactor::redact($request->query(), $keys, $replacement);
 
         $user->apiLogs()->create([
             'duration' => microtime(true) - $start,
-            'url' => $request->fullUrl(),
+            'url' => $query === [] ? $request->url() : $request->url().'?'.Arr::query($query),
             'method' => $request->getMethod(),
             'ip' => $request->getClientIp(),
-            'request_data' => $request->all(),
-            'request_headers' => $request->headers->all(),
-            'response_data' => is_string($content) ? json_decode($content) : null,
+            'request_data' => Redactor::redact($request->all(), $keys, $replacement),
+            'request_headers' => Redactor::redact($request->headers->all(), $headers, $replacement),
+            'response_data' => is_array($responseData) ? Redactor::redact($responseData, $keys, $replacement) : $responseData,
         ]);
     }
 }

--- a/src/Providers/ApiLogServiceProvider.php
+++ b/src/Providers/ApiLogServiceProvider.php
@@ -11,7 +11,7 @@ class ApiLogServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->mergeConfigFrom(__DIR__.'/../../config/api-logs.php', 'api-logs');
     }
 
     /**
@@ -32,5 +32,9 @@ class ApiLogServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../../database/migrations/create_api_logs_table.php.stub' => database_path($databasePath),
         ], 'migrations');
+
+        $this->publishes([
+            __DIR__.'/../../config/api-logs.php' => config_path('api-logs.php'),
+        ], 'config');
     }
 }

--- a/src/Support/Redactor.php
+++ b/src/Support/Redactor.php
@@ -10,16 +10,50 @@ class Redactor
      */
     public static function redact(array $data, array $keys, string $replacement): array
     {
-        $keys = array_map('strtolower', $keys);
+        return static::apply($data, static::lookup($keys), $replacement);
+    }
 
+    /**
+     * Replace the values of the given header names, matched
+     * case-insensitively, preserving the name => [values] shape.
+     */
+    public static function redactHeaders(array $headers, array $names, string $replacement): array
+    {
+        $lookup = static::lookup($names);
+
+        foreach ($headers as $name => $values) {
+            if (isset($lookup[strtolower((string) $name)])) {
+                $headers[$name] = [$replacement];
+            }
+        }
+
+        return $headers;
+    }
+
+    private static function apply(array $data, array $lookup, string $replacement): array
+    {
         foreach ($data as $key => $value) {
-            if (in_array(strtolower((string) $key), $keys, true)) {
+            if (isset($lookup[strtolower((string) $key)])) {
                 $data[$key] = $replacement;
             } elseif (is_array($value)) {
-                $data[$key] = static::redact($value, $keys, $replacement);
+                $data[$key] = static::apply($value, $lookup, $replacement);
             }
         }
 
         return $data;
+    }
+
+    /**
+     * @return array<string, true>
+     */
+    private static function lookup(array $keys): array
+    {
+        $lookup = [];
+
+        foreach ($keys as $key) {
+            $lookup[strtolower((string) $key)] = true;
+        }
+
+        return $lookup;
     }
 }

--- a/src/Support/Redactor.php
+++ b/src/Support/Redactor.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace CodeTech\ApiLogs\Support;
+
+class Redactor
+{
+    /**
+     * Replace the values of the given keys, matched case-insensitively and
+     * recursively, with the replacement string.
+     */
+    public static function redact(array $data, array $keys, string $replacement): array
+    {
+        $keys = array_map('strtolower', $keys);
+
+        foreach ($data as $key => $value) {
+            if (in_array(strtolower((string) $key), $keys, true)) {
+                $data[$key] = $replacement;
+            } elseif (is_array($value)) {
+                $data[$key] = static::redact($value, $keys, $replacement);
+            }
+        }
+
+        return $data;
+    }
+}

--- a/tests/LogApiRequestMiddlewareTest.php
+++ b/tests/LogApiRequestMiddlewareTest.php
@@ -67,7 +67,7 @@ class LogApiRequestMiddlewareTest extends TestCase
         $this->assertSame('[REDACTED]', $log->request_data['meta']['refresh_token']);
         $this->assertSame('user@example.com', $log->request_data['email']);
 
-        $this->assertSame('[REDACTED]', $log->request_headers['authorization']);
+        $this->assertSame(['[REDACTED]'], $log->request_headers['authorization']);
         $this->assertArrayHasKey('host', $log->request_headers);
 
         $this->assertSame('[REDACTED]', $log->response_data['access_token']);

--- a/tests/LogApiRequestMiddlewareTest.php
+++ b/tests/LogApiRequestMiddlewareTest.php
@@ -13,6 +13,10 @@ class LogApiRequestMiddlewareTest extends TestCase
         $router->middleware(LogApiRequest::class)->group(function () use ($router) {
             $router->get('/api/ping', fn () => response()->json(['pong' => true]));
             $router->post('/api/echo', fn () => response()->json(['ok' => true]));
+            $router->post('/api/login', fn () => response()->json([
+                'user' => ['email' => 'user@example.com'],
+                'access_token' => 'issued-token',
+            ]));
         });
     }
 
@@ -39,6 +43,59 @@ class LogApiRequestMiddlewareTest extends TestCase
         $this->assertSame(['ok' => true], (array) $log->response_data);
         $this->assertArrayHasKey('host', $log->request_headers);
         $this->assertTrue($log->causer->is($user));
+    }
+
+    public function test_sensitive_fields_are_redacted(): void
+    {
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'user@example.com',
+            'password' => 'secret',
+        ]);
+
+        $this->actingAs($user)
+            ->postJson('/api/login?api_token=query-token', [
+                'email' => 'user@example.com',
+                'password' => 'super-secret',
+                'meta' => ['refresh_token' => 'nested-token'],
+            ], ['Authorization' => 'Bearer abc123'])
+            ->assertOk();
+
+        $log = ApiLog::first();
+
+        $this->assertSame('[REDACTED]', $log->request_data['password']);
+        $this->assertSame('[REDACTED]', $log->request_data['meta']['refresh_token']);
+        $this->assertSame('user@example.com', $log->request_data['email']);
+
+        $this->assertSame('[REDACTED]', $log->request_headers['authorization']);
+        $this->assertArrayHasKey('host', $log->request_headers);
+
+        $this->assertSame('[REDACTED]', $log->response_data['access_token']);
+        $this->assertSame('user@example.com', $log->response_data['user']['email']);
+
+        $this->assertStringContainsString('api_token='.urlencode('[REDACTED]'), $log->url);
+        $this->assertStringNotContainsString('query-token', $log->url);
+    }
+
+    public function test_redaction_lists_are_configurable(): void
+    {
+        config()->set('api-logs.redact.keys', ['ssn']);
+        config()->set('api-logs.redact.replacement', '***');
+
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'user@example.com',
+            'password' => 'secret',
+        ]);
+
+        $this->actingAs($user)
+            ->postJson('/api/echo', ['ssn' => '123-45-6789', 'password' => 'kept-now'])
+            ->assertOk();
+
+        $log = ApiLog::first();
+
+        $this->assertSame('***', $log->request_data['ssn']);
+        $this->assertSame('kept-now', $log->request_data['password']);
     }
 
     public function test_unauthenticated_request_passes_through_and_is_not_logged(): void

--- a/tests/RedactorTest.php
+++ b/tests/RedactorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace CodeTech\ApiLogs\Tests;
+
+use CodeTech\ApiLogs\Support\Redactor;
+use PHPUnit\Framework\TestCase;
+
+class RedactorTest extends TestCase
+{
+    public function test_redacts_matching_keys_recursively(): void
+    {
+        $data = [
+            'email' => 'user@example.com',
+            'password' => 'secret123',
+            'profile' => [
+                'name' => 'Test',
+                'credentials' => [
+                    'api_token' => 'abc123',
+                ],
+            ],
+        ];
+
+        $result = Redactor::redact($data, ['password', 'api_token'], '[REDACTED]');
+
+        $this->assertSame('user@example.com', $result['email']);
+        $this->assertSame('[REDACTED]', $result['password']);
+        $this->assertSame('Test', $result['profile']['name']);
+        $this->assertSame('[REDACTED]', $result['profile']['credentials']['api_token']);
+    }
+
+    public function test_matches_keys_case_insensitively(): void
+    {
+        $result = Redactor::redact(
+            ['Authorization' => 'Bearer abc', 'X-API-KEY' => ['zzz']],
+            ['authorization', 'x-api-key'],
+            '[REDACTED]'
+        );
+
+        $this->assertSame('[REDACTED]', $result['Authorization']);
+        $this->assertSame('[REDACTED]', $result['X-API-KEY']);
+    }
+
+    public function test_replaces_array_values_entirely(): void
+    {
+        $result = Redactor::redact(
+            ['cookie' => ['session=1', 'other=2'], 'accept' => ['application/json']],
+            ['cookie'],
+            '[REDACTED]'
+        );
+
+        $this->assertSame('[REDACTED]', $result['cookie']);
+        $this->assertSame(['application/json'], $result['accept']);
+    }
+
+    public function test_leaves_data_untouched_when_nothing_matches(): void
+    {
+        $data = ['foo' => 'bar', 'nested' => ['baz' => 1]];
+
+        $this->assertSame($data, Redactor::redact($data, ['password'], '[REDACTED]'));
+    }
+}

--- a/tests/RedactorTest.php
+++ b/tests/RedactorTest.php
@@ -43,13 +43,38 @@ class RedactorTest extends TestCase
     public function test_replaces_array_values_entirely(): void
     {
         $result = Redactor::redact(
-            ['cookie' => ['session=1', 'other=2'], 'accept' => ['application/json']],
+            ['credit_card' => ['number' => '4111', 'cvv' => '123'], 'items' => [1, 2]],
+            ['credit_card'],
+            '[REDACTED]'
+        );
+
+        $this->assertSame('[REDACTED]', $result['credit_card']);
+        $this->assertSame([1, 2], $result['items']);
+    }
+
+    public function test_redact_headers_preserves_value_shape(): void
+    {
+        $result = Redactor::redactHeaders(
+            ['Cookie' => ['session=1', 'other=2'], 'accept' => ['application/json']],
             ['cookie'],
             '[REDACTED]'
         );
 
-        $this->assertSame('[REDACTED]', $result['cookie']);
+        $this->assertSame(['[REDACTED]'], $result['Cookie']);
         $this->assertSame(['application/json'], $result['accept']);
+    }
+
+    public function test_handles_non_string_keys(): void
+    {
+        $result = Redactor::redact(
+            ['password' => 'secret', 0 => 'zero', 1 => ['token' => 'abc']],
+            ['password', 123, 'token'],
+            '[REDACTED]'
+        );
+
+        $this->assertSame('[REDACTED]', $result['password']);
+        $this->assertSame('zero', $result[0]);
+        $this->assertSame('[REDACTED]', $result[1]['token']);
     }
 
     public function test_leaves_data_untouched_when_nothing_matches(): void


### PR DESCRIPTION
### Description

Sensitive values are now redacted before a log row is stored:

- **Request data & query string**: credential-type keys (`password`, `token`, `access_token`, …) matched case-insensitively and recursively
- **Request headers**: `Authorization`, `Proxy-Authorization`, `Cookie`, `X-Api-Key`, CSRF tokens, PHP basic-auth headers
- **Response data**: same key list as request data (protects token-issuing endpoints)
- **URL column**: the stored URL is rebuilt with redacted query parameters, so `?api_token=…` no longer leaks

Defaults live in a new publishable config (`php artisan vendor:publish --tag=config`) where the key/header lists and the replacement string (`[REDACTED]`) can be customized. Backwards compatible — no schema changes; rows logged before this release remain unredacted.

Includes unit tests for the redactor and end-to-end middleware tests (redaction + config override); README gains a Configuration section.

### Fixes

This fixes #11.