### PR TITLE
doc(versions): version visibility docs and Unit/Feature test split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /vendor
 /.phpunit.cache
 composer.lock
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The service provider is registered automatically via package discovery.
 Publish the migration file:
 
 ```
-php artisan vendor:publish --provider=CodeTech\\ApiLogs\\Providers\\ApiLogServiceProvider --tag=migrations
+php artisan vendor:publish --provider="CodeTech\ApiLogs\Providers\ApiLogServiceProvider" --tag=migrations
 ```
 
 Run the migration:
@@ -82,7 +82,7 @@ Sensitive values are **redacted by default** before a log is stored: common cred
 To customize the redaction lists or the replacement string, publish the config file:
 
 ```
-php artisan vendor:publish --provider=CodeTech\\ApiLogs\\Providers\\ApiLogServiceProvider --tag=config
+php artisan vendor:publish --provider="CodeTech\ApiLogs\Providers\ApiLogServiceProvider" --tag=config
 ```
 
 Then adjust `config/api-logs.php`:

--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@ A lightweight Laravel package for logging requests made to your API.
 
 ## Requirements
 
-| Package version | Laravel    | PHP  |
-|-----------------|------------|------|
-| 3.x             | 11 / 12 / 13 | ≥ 8.2 |
-| 2.x             | 7 – 10     | ≥ 7.2 |
+| Package version | Laravel    | PHP  | Status |
+|-----------------|------------|------|--------|
+| 3.x (this branch) | 11 / 12 / 13 | ≥ 8.2 | Active |
+| 2.x ([`v2`](https://github.com/CodeTechAgency/laravel-api-logs/tree/v2)) | 7 – 10 | ≥ 7.2 | Security fixes |
+| 1.x ([`v1`](https://github.com/CodeTechAgency/laravel-api-logs/tree/v1)) | 7 – 10 | ≥ 7.2 | End of life |
 
-Upgrading from 2.x? See the [upgrade guide](UPGRADE.md).
+Upgrading from an older version? See the [upgrade guide](UPGRADE.md).
 
 ## Installation
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -45,13 +45,13 @@ return Application::configure(basePath: dirname(__DIR__))
 
 ### Request timing is no longer stored in dynamic properties
 
-The middleware previously wrote `$request->start` and `$request->end` directly on the `Request` object (a dynamic property, deprecated since PHP 8.2). The start time now lives in the request attribute bag:
+The middleware wrote `$request->start` and `$request->end` directly on the `Request` object until 2.0 (a dynamic property, deprecated since PHP 8.2); since 2.1 and in 3.x the start time lives in the request attribute bag:
 
 ```php
 $request->attributes->get('api_logs.start');
 ```
 
-If your code read `$request->start` or `$request->end`, update it accordingly (`end` has no replacement — it was only ever the log's write time; use the `duration` column of the log instead).
+If your code read `$request->start` or `$request->end`, update it accordingly (`end` has no replacement — it was only ever the log's write time; use the `duration` column of the log instead). Upgrading from 2.1 or later, nothing changes here.
 
 ### Stricter middleware signatures
 
@@ -59,7 +59,7 @@ If your code read `$request->start` or `$request->end`, update it accordingly (`
 
 ### Users without the `HasApiLogs` trait are skipped
 
-`terminate()` now verifies that the authenticated model actually has an `apiLogs()` method before logging. In 2.x an authenticated model without the trait caused a fatal error; in 3.x the request is silently not logged. Make sure your user model uses the trait if you expect its requests to be logged:
+`terminate()` verifies that the authenticated model actually has an `apiLogs()` method before logging. In 2.0.x an authenticated model without the trait caused a fatal error; since 2.1 and in 3.x the request is silently not logged. Make sure your user model uses the trait if you expect its requests to be logged:
 
 ```php
 use CodeTech\ApiLogs\Traits\HasApiLogs;

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -81,3 +81,22 @@ The `$casts` property was replaced by the Laravel 11+ `casts()` method. If you e
 ### No database changes
 
 The `api_logs` table schema is unchanged — no new migration is required. (The published migration stub is now an anonymous class, which only affects migrations published after the upgrade.)
+
+## Upgrading from 3.0 to 3.1
+
+No changes are required — `composer update` is enough. Be aware of one behavioral change:
+
+### Sensitive fields are now redacted by default
+
+Since 3.1.0, credential-type fields in the request data, query string and response data (`password`, `token`, `access_token`, `secret`, `cvv`, …) and sensitive request headers (`Authorization`, `Cookie`, `X-Api-Key`, …) are stored as `[REDACTED]` instead of their real values. If you inspect stored payloads for debugging, expect to see redacted values for those keys.
+
+To customize which fields are redacted — or to restore the previous verbatim behavior by emptying the lists — publish the config file and edit `config/api-logs.php`:
+
+```
+php artisan vendor:publish --provider=CodeTech\\ApiLogs\\Providers\\ApiLogServiceProvider --tag=config
+```
+
+Two further notes:
+
+- Rows logged **before** 3.1.0 remain unredacted — if your `api_logs` table may contain credentials, consider purging or cleaning the historical data.
+- `response_data` is now decoded associatively before storage; reads through the `ApiLog` model are unchanged (the `json` cast already returned arrays).

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,14 @@
 # Upgrade Guide
 
+## Upgrading from 1.x to 2.0
+
+2.x supports the same Laravel (7–10) and PHP (≥ 7.2) versions as 1.x — the upgrade is a small schema and model change, and the 2.x line receives security fixes (e.g. sensitive-field redaction in 2.1.0) that 1.x does not.
+
+- **`user_id` FK → polymorphic `causer`**: add a `causer_type` column, backfill it with your user model's class name, rename `user_id` to `causer_id`, and index `['causer_type', 'causer_id']`. New installs simply publish and run the 2.x migration.
+- **Add the `HasApiLogs` trait** to your user model; read logs via `$user->apiLogs` / `$apiLog->causer` instead of `ApiLog::where('user_id', …)`.
+
+The full guide with migration snippets lives on the [`v1` branch](https://github.com/CodeTechAgency/laravel-api-logs/blob/v1/UPGRADE.md).
+
 ## Upgrading from 2.x to 3.0
 
 ### New requirements
@@ -15,7 +24,7 @@ Update your `composer.json`:
 "codetech/laravel-api-logs": "^3.0"
 ```
 
-If your application is still on Laravel 10 or older, stay on `^2.0` — v2.0.2 is the latest 2.x release.
+If your application is still on Laravel 10 or older, stay on `^2.0` — the 2.x line (on the [`v2` branch](https://github.com/CodeTechAgency/laravel-api-logs/tree/v2)) keeps receiving security fixes.
 
 ### Middleware registration has moved
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -93,7 +93,7 @@ Since 3.1.0, credential-type fields in the request data, query string and respon
 To customize which fields are redacted — or to restore the previous verbatim behavior by emptying the lists — publish the config file and edit `config/api-logs.php`:
 
 ```
-php artisan vendor:publish --provider=CodeTech\\ApiLogs\\Providers\\ApiLogServiceProvider --tag=config
+php artisan vendor:publish --provider="CodeTech\ApiLogs\Providers\ApiLogServiceProvider" --tag=config
 ```
 
 Two further notes:

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,8 +4,11 @@
          colors="true"
          cacheDirectory=".phpunit.cache">
     <testsuites>
-        <testsuite name="Package">
-            <directory>tests</directory>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Feature">
+            <directory>tests/Feature</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/tests/Feature/HasApiLogsTest.php
+++ b/tests/Feature/HasApiLogsTest.php
@@ -1,9 +1,10 @@
 <?php
 
-namespace CodeTech\ApiLogs\Tests;
+namespace CodeTech\ApiLogs\Tests\Feature;
 
 use CodeTech\ApiLogs\Models\ApiLog;
 use CodeTech\ApiLogs\Tests\Fixtures\User;
+use CodeTech\ApiLogs\Tests\TestCase;
 
 class HasApiLogsTest extends TestCase
 {

--- a/tests/Feature/LogApiRequestMiddlewareTest.php
+++ b/tests/Feature/LogApiRequestMiddlewareTest.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace CodeTech\ApiLogs\Tests;
+namespace CodeTech\ApiLogs\Tests\Feature;
 
 use CodeTech\ApiLogs\Http\Middleware\LogApiRequest;
 use CodeTech\ApiLogs\Models\ApiLog;
 use CodeTech\ApiLogs\Tests\Fixtures\User;
+use CodeTech\ApiLogs\Tests\TestCase;
 
 class LogApiRequestMiddlewareTest extends TestCase
 {

--- a/tests/Unit/RedactorTest.php
+++ b/tests/Unit/RedactorTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace CodeTech\ApiLogs\Tests;
+namespace CodeTech\ApiLogs\Tests\Unit;
 
 use CodeTech\ApiLogs\Support\Redactor;
-use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 
-class RedactorTest extends TestCase
+class RedactorTest extends PHPUnitTestCase
 {
     public function test_redacts_matching_keys_recursively(): void
     {


### PR DESCRIPTION
### Description

Version-visibility docs on the default branch, plus the Laravel-convention test layout:

**Docs**
- README requirements table gains a Status column and links to the `v2` / `v1` maintenance branches (1.x row added)
- `UPGRADE.md` gains the 1.x → 2.0 section, so the full upgrade path (1 → 2 → 3) is discoverable from `main`, and a 3.0 → 3.1 section documenting the default-on redaction
- Timing/trait-guard notes in the 2.x → 3.0 section now correctly attribute those changes to 2.1
- `vendor:publish` snippets use a quoted, single-backslash provider argument (portable across shells)

**Tests**
- Tests split into `tests/Unit` and `tests/Feature` (Laravel convention) with separate PHPUnit testsuites; namespaces follow the directories
- `RedactorTest` parent import aliased to `PHPUnitTestCase` for clarity

### Fixes

This fixes #15 (main part; #16 covers the `v1` branch — ideally merge that first, since merging this PR auto-closes the issue).
