### PR TITLE
doc(commands): quote provider argument in vendor:publish snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The service provider will be automatically registered during the installation pr
 Publish the migration file:
 
 ```
-php artisan vendor:publish --provider=CodeTech\\ApiLogs\\Providers\\ApiLogServiceProvider --tag=migrations
+php artisan vendor:publish --provider="CodeTech\ApiLogs\Providers\ApiLogServiceProvider" --tag=migrations
 ```
 
 Run the migration:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@ A lightweight Laravel package for logging requests made to your API.
 [![Latest version](https://img.shields.io/github/release/CodeTechAgency/laravel-api-logs?style=flat-square)](https://github.com/CodeTechAgency/laravel-api-logs/releases)
 [![GitHub license](https://img.shields.io/github/license/CodeTechAgency/laravel-api-logs?style=flat-square)](https://github.com/CodeTechAgency/laravel-api-logs/blob/master/LICENSE)
 
+> **⚠️ You are viewing the docs for 1.x, which is end-of-life** and receives no further updates — including security fixes such as the sensitive-field redaction added in 2.1.0 (without it, passwords and tokens are stored verbatim in your database). Upgrading to 2.x is a small change — see the [upgrade guide](UPGRADE.md). The latest version is 3.x (Laravel 11–13) on the [`main`](https://github.com/CodeTechAgency/laravel-api-logs/tree/main) branch.
+
+## Requirements
+
+| Package version | Laravel      | PHP   | Status |
+|-----------------|--------------|-------|--------|
+| 3.x ([`main`](https://github.com/CodeTechAgency/laravel-api-logs/tree/main)) | 11 / 12 / 13 | ≥ 8.2 | Active |
+| 2.x ([`v2`](https://github.com/CodeTechAgency/laravel-api-logs/tree/v2)) | 7 – 10 | ≥ 7.2 | Security fixes |
+| 1.x (this branch) | 7 – 10 | ≥ 7.2 | End of life |
+
 ## Installation
 
 Add the package to your Laravel application using composer:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The service provider will be automatically registered during the installation pr
 ```
 'providers' => [
     ...
-    Codetech\ApiLogs\Providers\ApiLogServiceProvider::class,
+    CodeTech\ApiLogs\Providers\ApiLogServiceProvider::class,
 
 ],
 ```

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -15,22 +15,25 @@ Update your `composer.json`:
 The `api_logs` table no longer has a `user_id` foreign key; logs are linked to the model that made the request through a polymorphic relation. Migrate your existing table:
 
 ```php
+// 1. Drop the FK and add the new (nullable) type column
 Schema::table('api_logs', function (Blueprint $table) {
     $table->dropForeign(['user_id']);
+    $table->string('causer_type')->nullable()->after('user_id');
 });
 
+// 2. Backfill the type with your user model's class name
 DB::table('api_logs')->update([
-    'causer_type' => \App\Models\User::class, // set before renaming, see below
+    'causer_type' => \App\Models\User::class,
 ]);
 
+// 3. Rename the id column and add the morph index
 Schema::table('api_logs', function (Blueprint $table) {
     $table->renameColumn('user_id', 'causer_id');
-    $table->string('causer_type')->after('causer_id');
     $table->index(['causer_type', 'causer_id'], 'causer');
 });
 ```
 
-(Adjust order/steps to your database driver: add the `causer_type` column first, backfill it with your user model's class name, then rename `user_id` to `causer_id` and add the index. New installs can simply publish and run the 2.x migration.)
+Notes: `causer_type` is created nullable so the backfill can run; you may tighten it to `NOT NULL` afterwards if you wish (on Laravel ≤ 10, column changes require the `doctrine/dbal` package). Fresh installs can skip all of this and simply publish and run the 2.x migration.
 
 ### Add the `HasApiLogs` trait to your user model
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,52 @@
+# Upgrade Guide
+
+## Upgrading from 1.x to 2.0
+
+2.x supports the same Laravel (7–10) and PHP (≥ 7.2) versions as 1.x — the upgrade is a small schema and model change. It is strongly recommended: the 2.x line receives security fixes, including sensitive-field redaction (2.1.0), which 1.x lacks.
+
+Update your `composer.json`:
+
+```json
+"codetech/laravel-api-logs": "^2.0"
+```
+
+### The `user_id` column was replaced by a polymorphic `causer`
+
+The `api_logs` table no longer has a `user_id` foreign key; logs are linked to the model that made the request through a polymorphic relation. Migrate your existing table:
+
+```php
+Schema::table('api_logs', function (Blueprint $table) {
+    $table->dropForeign(['user_id']);
+});
+
+DB::table('api_logs')->update([
+    'causer_type' => \App\Models\User::class, // set before renaming, see below
+]);
+
+Schema::table('api_logs', function (Blueprint $table) {
+    $table->renameColumn('user_id', 'causer_id');
+    $table->string('causer_type')->after('causer_id');
+    $table->index(['causer_type', 'causer_id'], 'causer');
+});
+```
+
+(Adjust order/steps to your database driver: add the `causer_type` column first, backfill it with your user model's class name, then rename `user_id` to `causer_id` and add the index. New installs can simply publish and run the 2.x migration.)
+
+### Add the `HasApiLogs` trait to your user model
+
+The logs are now written through the authenticated model's `apiLogs()` relation:
+
+```php
+use CodeTech\ApiLogs\Traits\HasApiLogs;
+
+class User extends Authenticatable
+{
+    use HasApiLogs;
+}
+```
+
+Reading logs changes from querying `ApiLog::where('user_id', …)` to `$user->apiLogs` / `$apiLog->causer`.
+
+## Upgrading from 2.x to 3.0
+
+3.x requires PHP ≥ 8.2 and Laravel 11–13. See the full guide on the [`v2` branch](https://github.com/CodeTechAgency/laravel-api-logs/blob/v2/UPGRADE.md) or on [`main`](https://github.com/CodeTechAgency/laravel-api-logs/blob/main/UPGRADE.md).


### PR DESCRIPTION
### Description

Follow-up to #16 (merged before this landed): the `vendor:publish` snippet in the v1 README now uses a quoted, single-backslash provider argument — the unquoted doubled-backslash form breaks on Windows shells. Same fix as applied to `main` in #17.

### Fixes

Part of #15 (v1 follow-up).