### PR TITLE
doc(readme): use absolute upgrade-guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A lightweight Laravel package for logging requests made to your API.
 
 [![Latest version](https://img.shields.io/github/release/CodeTechAgency/laravel-api-logs?style=flat-square)](https://github.com/CodeTechAgency/laravel-api-logs/releases)
-[![GitHub license](https://img.shields.io/github/license/CodeTechAgency/laravel-api-logs?style=flat-square)](https://github.com/CodeTechAgency/laravel-api-logs/blob/master/LICENSE)
+[![GitHub license](https://img.shields.io/github/license/CodeTechAgency/laravel-api-logs?style=flat-square)](https://github.com/CodeTechAgency/laravel-api-logs/blob/v1/LICENSE)
 
 > **⚠️ You are viewing the docs for 1.x, which is end-of-life** and receives no further updates — including security fixes such as the sensitive-field redaction added in 2.1.0 (without it, passwords and tokens are stored verbatim in your database). Upgrading to 2.x is a small change — see the [upgrade guide](https://github.com/CodeTechAgency/laravel-api-logs/blob/v1/UPGRADE.md). The latest version is 3.x (Laravel 11–13) on the [`main`](https://github.com/CodeTechAgency/laravel-api-logs/tree/main) branch.
 
@@ -74,7 +74,7 @@ protected $middlewareGroups = [
 
 ## License
 
-**codetech/laravel-api-logs** is open-sourced software licensed under the [MIT license](https://github.com/CodeTechAgency/laravel-api-logs/blob/master/LICENSE).
+**codetech/laravel-api-logs** is open-sourced software licensed under the [MIT license](https://github.com/CodeTechAgency/laravel-api-logs/blob/v1/LICENSE).
 
 
 ## About CodeTech

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ A lightweight Laravel package for logging requests made to your API.
 
 ## Requirements
 
-| Package version | Laravel      | PHP   | Status |
-|-----------------|--------------|-------|--------|
-| 3.x ([`main`](https://github.com/CodeTechAgency/laravel-api-logs/tree/main)) | 11 / 12 / 13 | ≥ 8.2 | Active |
-| 2.x ([`v2`](https://github.com/CodeTechAgency/laravel-api-logs/tree/v2)) | 7 – 10 | ≥ 7.2 | Security fixes |
-| 1.x (this branch) | 7 – 10 | ≥ 7.2 | End of life |
+| Package version                                                              | Laravel      | PHP   | Status         |
+|------------------------------------------------------------------------------|--------------|-------|----------------|
+| 3.x ([`main`](https://github.com/CodeTechAgency/laravel-api-logs/tree/main)) | 11 / 12 / 13 | ≥ 8.2 | Active         |
+| 2.x ([`v2`](https://github.com/CodeTechAgency/laravel-api-logs/tree/v2))     | 7 – 10       | ≥ 7.2 | Security fixes |
+| 1.x (this branch)                                                            | 7 – 10       | ≥ 7.2 | End of life    |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A lightweight Laravel package for logging requests made to your API.
 [![Latest version](https://img.shields.io/github/release/CodeTechAgency/laravel-api-logs?style=flat-square)](https://github.com/CodeTechAgency/laravel-api-logs/releases)
 [![GitHub license](https://img.shields.io/github/license/CodeTechAgency/laravel-api-logs?style=flat-square)](https://github.com/CodeTechAgency/laravel-api-logs/blob/master/LICENSE)
 
-> **⚠️ You are viewing the docs for 1.x, which is end-of-life** and receives no further updates — including security fixes such as the sensitive-field redaction added in 2.1.0 (without it, passwords and tokens are stored verbatim in your database). Upgrading to 2.x is a small change — see the [upgrade guide](UPGRADE.md). The latest version is 3.x (Laravel 11–13) on the [`main`](https://github.com/CodeTechAgency/laravel-api-logs/tree/main) branch.
+> **⚠️ You are viewing the docs for 1.x, which is end-of-life** and receives no further updates — including security fixes such as the sensitive-field redaction added in 2.1.0 (without it, passwords and tokens are stored verbatim in your database). Upgrading to 2.x is a small change — see the [upgrade guide](https://github.com/CodeTechAgency/laravel-api-logs/blob/v1/UPGRADE.md). The latest version is 3.x (Laravel 11–13) on the [`main`](https://github.com/CodeTechAgency/laravel-api-logs/tree/main) branch.
 
 ## Requirements
 


### PR DESCRIPTION
Closes #28

- The relative `(UPGRADE.md)` link 404s when the README is rendered outside GitHub; replaced with the absolute URL to the v1 branch's upgrade guide
- The LICENSE links pointed at a nonexistent `master` branch; now point at `v1`

Note: since this PR targets `v1` (not the default branch), GitHub won't auto-close #28 on merge — it gets closed manually afterwards.