### PR TITLE
doc(readme): use absolute upgrade-guide link and fix license links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 A lightweight Laravel package for logging requests made to your API.
 
 [![Latest version](https://img.shields.io/github/release/CodeTechAgency/laravel-api-logs?style=flat-square)](https://github.com/CodeTechAgency/laravel-api-logs/releases)
-[![GitHub license](https://img.shields.io/github/license/CodeTechAgency/laravel-api-logs?style=flat-square)](https://github.com/CodeTechAgency/laravel-api-logs/blob/master/LICENSE)
+[![GitHub license](https://img.shields.io/github/license/CodeTechAgency/laravel-api-logs?style=flat-square)](https://github.com/CodeTechAgency/laravel-api-logs/blob/v2/LICENSE)
 
-> **You are viewing the docs for the 2.x line** (Laravel 7–10). The latest version is 3.x (Laravel 11–13) on the [`main`](https://github.com/CodeTechAgency/laravel-api-logs/tree/main) branch — see the [upgrade guide](UPGRADE.md).
+> **You are viewing the docs for the 2.x line** (Laravel 7–10). The latest version is 3.x (Laravel 11–13) on the [`main`](https://github.com/CodeTechAgency/laravel-api-logs/tree/main) branch — see the [upgrade guide](https://github.com/CodeTechAgency/laravel-api-logs/blob/v2/UPGRADE.md).
 
 ## Requirements
 
@@ -92,7 +92,7 @@ composer test
 
 ## License
 
-**codetech/laravel-api-logs** is open-sourced software licensed under the [MIT license](https://github.com/CodeTechAgency/laravel-api-logs/blob/master/LICENSE).
+**codetech/laravel-api-logs** is open-sourced software licensed under the [MIT license](https://github.com/CodeTechAgency/laravel-api-logs/blob/v2/LICENSE).
 
 
 ## About CodeTech


### PR DESCRIPTION
Closes #29

- The relative `(UPGRADE.md)` link 404s when the README is rendered outside GitHub; replaced with the absolute URL to the v2 branch's upgrade guide
- The LICENSE links pointed at a nonexistent `master` branch; now point at `v2`

Note: since this PR targets `v2` (not the default branch), GitHub won't auto-close #29 on merge — it gets closed manually afterwards.