### PR TITLE
chore(quality): add Pint code style and PHPStan static analysis

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,3 +46,27 @@ jobs:
 
       - name: Run tests
         run: vendor/bin/phpunit
+
+  quality:
+    runs-on: ubuntu-latest
+    name: Code quality
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: mbstring, pdo, sqlite3, pdo_sqlite
+          coverage: none
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-interaction --no-progress
+
+      - name: Check code style (Pint)
+        run: composer lint
+
+      - name: Run static analysis (PHPStan)
+        run: composer analyse

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,9 @@
   },
   "require-dev": {
     "orchestra/testbench": "^9.0|^10.0|^11.0",
-    "phpunit/phpunit": "^10.5|^11.0|^12.0"
+    "phpunit/phpunit": "^10.5|^11.0|^12.0",
+    "laravel/pint": "^1.29",
+    "larastan/larastan": "^3.10"
   },
   "autoload": {
     "psr-4": {
@@ -37,6 +39,9 @@
     }
   },
   "scripts": {
+    "analyse": "vendor/bin/phpstan analyse --memory-limit=1G",
+    "format": "vendor/bin/pint",
+    "lint": "vendor/bin/pint --test",
     "test": "phpunit"
   },
   "minimum-stability": "dev",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,15 @@
+includes:
+    - vendor/larastan/larastan/extension.neon
+
+parameters:
+    paths:
+        - src
+
+    level: 5
+
+    ignoreErrors:
+        # Package traits are consumed by userland models, not by the
+        # package itself, so they are never "used" from PHPStan's view.
+        -
+            identifier: trait.unused
+            path: src/Traits/HasApiLogs.php

--- a/pint.json
+++ b/pint.json
@@ -1,0 +1,3 @@
+{
+    "preset": "laravel"
+}

--- a/src/Models/ApiLog.php
+++ b/src/Models/ApiLog.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 class ApiLog extends Model
 {
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     protected $fillable = [
         'duration',

--- a/src/Support/Redactor.php
+++ b/src/Support/Redactor.php
@@ -10,7 +10,7 @@ class Redactor
      */
     public static function redact(array $data, array $keys, string $replacement): array
     {
-        return static::apply($data, static::lookup($keys), $replacement);
+        return self::apply($data, self::lookup($keys), $replacement);
     }
 
     /**
@@ -19,7 +19,7 @@ class Redactor
      */
     public static function redactHeaders(array $headers, array $names, string $replacement): array
     {
-        $lookup = static::lookup($names);
+        $lookup = self::lookup($names);
 
         foreach ($headers as $name => $values) {
             if (isset($lookup[strtolower((string) $name)])) {
@@ -36,7 +36,7 @@ class Redactor
             if (isset($lookup[strtolower((string) $key)])) {
                 $data[$key] = $replacement;
             } elseif (is_array($value)) {
-                $data[$key] = static::apply($value, $lookup, $replacement);
+                $data[$key] = self::apply($value, $lookup, $replacement);
             }
         }
 


### PR DESCRIPTION
Closes #23

Mirrors the quality setup used in codetech/laravel-eupago:

- `laravel/pint` (^1.29) with the `laravel` preset
- `larastan/larastan` (^3.10) at level 5 over `src/`, with an ignore for the userland-consumed `HasApiLogs` trait
- Composer scripts: `lint`, `format`, `analyse`
- New `quality` CI job running Pint and PHPStan alongside the test matrix

Findings fixed in a separate commit: one Pint phpdoc fix in `ApiLog`, and `Redactor`'s private methods are now called via `self::` instead of `static::`.

Note: README does not yet document the new commands — that lands after #20 merges to avoid conflicting edits to the Testing section.

Local runs: `composer lint`, `composer analyse` and `composer test` (11 tests, 43 assertions) all pass.