### PR TITLE
doc(contributing): add contributing guidelines and security policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing
+
+Thanks for considering contributing to **codetech/laravel-api-logs**!
+
+## Which branch?
+
+- **New features and improvements**: target the [`main`](https://github.com/CodeTechAgency/laravel-api-logs/tree/main) branch (3.x, Laravel 11–13).
+- **Security fixes for the 2.x line**: target the [`v2`](https://github.com/CodeTechAgency/laravel-api-logs/tree/v2) branch. No other changes are accepted there.
+- The [`v1`](https://github.com/CodeTechAgency/laravel-api-logs/tree/v1) branch is end-of-life and receives no changes.
+
+## Getting started
+
+```bash
+git clone git@github.com:CodeTechAgency/laravel-api-logs.git
+cd laravel-api-logs
+composer install
+```
+
+## Before submitting a pull request
+
+Run the full quality suite locally — CI runs the same checks:
+
+```bash
+composer test      # PHPUnit test suite (Unit + Feature)
+composer lint      # Pint code-style check (run `composer format` to fix)
+composer analyse   # PHPStan static analysis
+```
+
+- Add tests for any change in behaviour. Unit tests live in `tests/Unit`, feature tests in `tests/Feature`.
+- Keep pull requests focused: one feature or fix per PR.
+- Use a [conventional-commit](https://www.conventionalcommits.org) style title, e.g. `fix(middleware): handle missing causer`.
+- Reference the related issue in the PR description. If there is no issue yet, please open one first so the change can be discussed.
+
+## Reporting bugs
+
+Open an issue using the bug report template and include the package, Laravel and PHP versions plus the smallest reproduction you can manage.
+
+**Security vulnerabilities must not be reported publicly** — see the [security policy](https://github.com/CodeTechAgency/laravel-api-logs/blob/main/SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -102,17 +102,27 @@ return [
 
 `keys` are matched case-insensitively and recursively against the request payload, query string and response data; `headers` are matched against request header names.
 
-## Testing
+## Testing & code quality
 
-The test suite is split into `Unit` and `Feature` suites. Run everything with:
+The test suite is split into `Unit` and `Feature` suites. Run the tests, static analysis and code-style checks via Composer:
 
-```
-composer test
+```bash
+composer test      # PHPUnit test suite
+composer analyse   # PHPStan/Larastan static analysis
+composer lint      # Pint code-style check (run `composer format` to fix)
 ```
 
 ## Changelog
 
 Every release is documented on the [GitHub releases page](https://github.com/CodeTechAgency/laravel-api-logs/releases).
+
+## Contributing
+
+Contributions are welcome! Please read the [contributing guidelines](https://github.com/CodeTechAgency/laravel-api-logs/blob/main/CONTRIBUTING.md) before opening an issue or pull request.
+
+## Security
+
+If you discover a security vulnerability, please follow the [security policy](https://github.com/CodeTechAgency/laravel-api-logs/blob/main/SECURITY.md) — do not report it publicly.
 
 ## Support
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Supported |
+|---------|-----------|
+| 3.x | ✅ Active support |
+| 2.x | ⚠️ Security fixes only |
+| 1.x | ❌ End of life |
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Report them privately via [GitHub Security Advisories](https://github.com/CodeTechAgency/laravel-api-logs/security/advisories/new). If that is not an option, email the maintainer at jfrosorio@gmail.com.
+
+You will receive a response as soon as possible. Once the issue is confirmed, a fix is prepared for all supported versions and released together with an advisory crediting the reporter (unless you prefer to remain anonymous).


### PR DESCRIPTION
Closes #25

- `CONTRIBUTING.md`: branch targeting (main for features, v2 for security fixes only, v1 EOL), dev setup, quality-suite commands, PR conventions
- `SECURITY.md`: supported-versions table and private disclosure via GitHub Security Advisories with email fallback
- README: renames Testing to "Testing & code quality" documenting the `lint`/`analyse`/`format` scripts from #24, and adds Contributing and Security sections linking the new docs

Rebased onto main after #20 and #24 merged, so the composer scripts referenced by the contributing guide exist on this branch.