### PR TITLE
feat(guard): add guard config option to control auth guard used for logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ $apiLog->causer; // the model that made the request
 
 Sensitive values are **redacted by default** before a log is stored: common credential fields (`password`, `token`, `access_token`, …) in the request data, query string and response data, and sensitive request headers (`Authorization`, `Cookie`, `X-Api-Key`, …) are replaced with `[REDACTED]`.
 
-To customize the redaction lists or the replacement string, publish the config file:
+To customize the authentication guard, the redaction lists or the replacement string, publish the config file:
 
 ```
 php artisan vendor:publish --provider="CodeTech\ApiLogs\Providers\ApiLogServiceProvider" --tag=config
@@ -92,6 +92,8 @@ Then adjust `config/api-logs.php`:
 
 ```php
 return [
+    'guard' => null,
+
     'redact' => [
         'replacement' => '[REDACTED]',
         'keys' => ['password', 'access_token' /* , ... */],
@@ -99,6 +101,8 @@ return [
     ],
 ];
 ```
+
+`guard` pins the authentication guard used to resolve the user a logged request is attributed to (e.g. `'sanctum'`). When `null`, the request's default guard is used — the one set by the `auth` middleware, or the application's default guard.
 
 `keys` are matched case-insensitively and recursively against the request payload, query string and response data; `headers` are matched against request header names.
 

--- a/config/api-logs.php
+++ b/config/api-logs.php
@@ -4,6 +4,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Authentication Guard
+    |--------------------------------------------------------------------------
+    |
+    | The authentication guard used to resolve the user a logged request is
+    | attributed to. When null, the request's default guard is used (the one
+    | set by the auth middleware, or the application's default guard).
+    |
+    */
+
+    'guard' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | Redaction
     |--------------------------------------------------------------------------
     |

--- a/src/Http/Middleware/LogApiRequest.php
+++ b/src/Http/Middleware/LogApiRequest.php
@@ -25,7 +25,7 @@ class LogApiRequest
      */
     public function terminate(Request $request, Response $response): void
     {
-        $user = auth()->user();
+        $user = auth()->guard(config('api-logs.guard'))->user();
 
         if ($user === null || ! method_exists($user, 'apiLogs')) {
             return;

--- a/tests/Feature/LogApiRequestMiddlewareTest.php
+++ b/tests/Feature/LogApiRequestMiddlewareTest.php
@@ -99,6 +99,49 @@ class LogApiRequestMiddlewareTest extends TestCase
         $this->assertSame('kept-now', $log->request_data['password']);
     }
 
+    public function test_configured_guard_is_used_to_resolve_the_user(): void
+    {
+        $this->defineApiGuard();
+        config()->set('api-logs.guard', 'api');
+
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'user@example.com',
+            'password' => 'secret',
+        ]);
+
+        $this->actingAs($user, 'api')
+            ->postJson('/api/echo', ['name' => 'value'])
+            ->assertOk();
+
+        $this->assertSame(1, ApiLog::count());
+        $this->assertTrue(ApiLog::first()->causer->is($user));
+    }
+
+    public function test_request_is_not_logged_when_configured_guard_is_unauthenticated(): void
+    {
+        $this->defineApiGuard();
+        config()->set('api-logs.guard', 'api');
+
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'user@example.com',
+            'password' => 'secret',
+        ]);
+
+        $this->actingAs($user, 'web')
+            ->postJson('/api/echo', ['name' => 'value'])
+            ->assertOk();
+
+        $this->assertSame(0, ApiLog::count());
+    }
+
+    private function defineApiGuard(): void
+    {
+        config()->set('auth.guards.api', ['driver' => 'session', 'provider' => 'users']);
+        config()->set('auth.providers.users', ['driver' => 'eloquent', 'model' => User::class]);
+    }
+
     public function test_unauthenticated_request_passes_through_and_is_not_logged(): void
     {
         $this->getJson('/api/ping')


### PR DESCRIPTION
Closes #30

The `LogApiRequest` middleware resolved the user via `auth()->user()`, i.e. the request's default guard. When no `auth:<guard>` middleware had called `shouldUse()`, this silently fell back to `config('auth.defaults.guard')` (typically `web`), which may not be the guard the application authenticates its API with.

This PR adds a `guard` option to `config/api-logs.php`:

- `'guard' => null` (default) keeps the current behavior — the request's default guard is used.
- Setting a guard name (e.g. `'sanctum'`) pins the guard used to resolve the user a logged request is attributed to.

Includes feature tests covering both the configured-guard-authenticated and configured-guard-unauthenticated cases, plus README documentation.