### PR TITLE
docs(structure): move documentation from README to a docs/ folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Append the middleware to the `api` middleware group in your `bootstrap/app.php`:
 
 ```php
 use CodeTech\ApiLogs\Http\Middleware\LogApiRequest;
+use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Middleware;
 
 return Application::configure(basePath: dirname(__DIR__))

--- a/README.md
+++ b/README.md
@@ -2,61 +2,25 @@
 
 # Laravel API Requests Logger
 
-A lightweight Laravel package for logging requests made to your API.
-
 [![Latest version](https://img.shields.io/github/release/CodeTechAgency/laravel-api-logs?style=flat-square)](https://github.com/CodeTechAgency/laravel-api-logs/releases)
 [![Total downloads](https://img.shields.io/packagist/dt/codetech/laravel-api-logs?style=flat-square)](https://packagist.org/packages/codetech/laravel-api-logs)
 [![Tests](https://img.shields.io/github/actions/workflow/status/CodeTechAgency/laravel-api-logs/tests.yml?style=flat-square&label=tests)](https://github.com/CodeTechAgency/laravel-api-logs/actions/workflows/tests.yml)
 [![GitHub license](https://img.shields.io/github/license/CodeTechAgency/laravel-api-logs?style=flat-square)](https://github.com/CodeTechAgency/laravel-api-logs/blob/main/LICENSE)
 
-## Requirements
+A lightweight Laravel package for logging the requests made to your API. Each
+authenticated request is stored with its URL, method, IP, payload, headers, response,
+and duration — linked to the user that made it, with sensitive values redacted before
+anything hits the database.
 
-| Package version                                                          | Laravel      | PHP   | Status         |
-|--------------------------------------------------------------------------|--------------|-------|----------------|
-| 3.x (this branch)                                                        | 11 / 12 / 13 | ≥ 8.2 | Active         |
-| 2.x ([`v2`](https://github.com/CodeTechAgency/laravel-api-logs/tree/v2)) | 7 – 10       | ≥ 7.2 | Security fixes |
-| 1.x ([`v1`](https://github.com/CodeTechAgency/laravel-api-logs/tree/v1)) | 7 – 10       | ≥ 7.2 | End of life    |
+## Quick start
 
-Upgrading from an older version? See the [upgrade guide](https://github.com/CodeTechAgency/laravel-api-logs/blob/main/UPGRADE.md).
-
-## Installation
-
-Add the package to your Laravel application using composer:
-
-```
+```bash
 composer require codetech/laravel-api-logs
-```
-
-The service provider is registered automatically via package discovery.
-
-### Migrations
-
-Publish the migration file:
-
-```
 php artisan vendor:publish --provider="CodeTech\ApiLogs\Providers\ApiLogServiceProvider" --tag=migrations
-```
-
-Run the migration:
-
-```
 php artisan migrate
 ```
 
-## Usage
-
-Add the `HasApiLogs` trait to the model that makes the requests (typically your `User` model):
-
-```php
-use CodeTech\ApiLogs\Traits\HasApiLogs;
-
-class User extends Authenticatable
-{
-    use HasApiLogs;
-}
-```
-
-To start logging requests made to your API, append the middleware to the `api` middleware group in your `bootstrap/app.php`:
+Append the middleware to the `api` middleware group in your `bootstrap/app.php`:
 
 ```php
 use CodeTech\ApiLogs\Http\Middleware\LogApiRequest;
@@ -71,50 +35,25 @@ return Application::configure(basePath: dirname(__DIR__))
     ->create();
 ```
 
-Only authenticated requests are logged. Each log stores the URL, HTTP method, client IP, request data, request headers, response data and the request duration, and is linked to the authenticated user through a polymorphic `causer` relation:
+Add the `HasApiLogs` trait to the model that makes the requests to browse its history:
 
 ```php
+use CodeTech\ApiLogs\Traits\HasApiLogs;
+
+class User extends Authenticatable
+{
+    use HasApiLogs;
+}
+
 $user->apiLogs; // all ApiLog entries for the user
-$apiLog->causer; // the model that made the request
 ```
 
-## Configuration
+## Documentation
 
-Sensitive values are **redacted by default** before a log is stored: common credential fields (`password`, `token`, `access_token`, …) in the request data, query string and response data, and sensitive request headers (`Authorization`, `Cookie`, `X-Api-Key`, …) are replaced with `[REDACTED]`.
+To learn all about the package — configuration, guards, redaction — head over to
+[the extensive documentation](https://www.codetech.pt/open-source/laravel-api-logs).
 
-To customize the authentication guard, the redaction lists or the replacement string, publish the config file:
-
-```
-php artisan vendor:publish --provider="CodeTech\ApiLogs\Providers\ApiLogServiceProvider" --tag=config
-```
-
-Then adjust `config/api-logs.php`:
-
-```php
-return [
-    'guard' => null,
-
-    'redact' => [
-        'replacement' => '[REDACTED]',
-        'keys' => ['password', 'access_token' /* , ... */],
-        'headers' => ['authorization', 'cookie' /* , ... */],
-    ],
-];
-```
-
-`guard` pins the authentication guard used to resolve the user a logged request is attributed to (e.g. `'sanctum'`). When `null`, the request's default guard is used — the one set by the `auth` middleware, or the application's default guard.
-
-`keys` are matched case-insensitively and recursively against the request payload, query string and response data; `headers` are matched against request header names.
-
-## Testing & code quality
-
-The test suite is split into `Unit` and `Feature` suites. Run the tests, static analysis and code-style checks via Composer:
-
-```bash
-composer test      # PHPUnit test suite
-composer analyse   # PHPStan/Larastan static analysis
-composer lint      # Pint code-style check (run `composer format` to fix)
-```
+Upgrading from an older version? See the [upgrade guide](https://github.com/CodeTechAgency/laravel-api-logs/blob/main/UPGRADE.md).
 
 ## Changelog
 
@@ -130,13 +69,15 @@ If you discover a security vulnerability, please follow the [security policy](ht
 
 ## Support
 
-If this package helps you, consider [starring the repository](https://github.com/CodeTechAgency/laravel-api-logs) — it helps other developers discover it.
+If this package helps you, consider [starring the repository](https://github.com/CodeTechAgency/laravel-api-logs) —
+it helps other developers discover it.
 
 ---
 
 ## License
 
-**codetech/laravel-api-logs** is open-sourced software licensed under the [MIT license](https://github.com/CodeTechAgency/laravel-api-logs/blob/main/LICENSE).
+**codetech/laravel-api-logs** is open-sourced software licensed under
+the [MIT license](https://github.com/CodeTechAgency/laravel-api-logs/blob/main/LICENSE).
 
 ## About CodeTech
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,37 @@
+---
+title: Configuration
+weight: 4
+group: Getting started
+---
+
+The package works out of the box with sensible defaults. To change them, publish the
+config file:
+
+```bash
+php artisan vendor:publish --provider="CodeTech\ApiLogs\Providers\ApiLogServiceProvider" --tag=config
+```
+
+Then adjust `config/api-logs.php`:
+
+```php
+return [
+    'guard' => null,
+
+    'redact' => [
+        'replacement' => '[REDACTED]',
+        'keys' => ['password', 'access_token' /* , ... */],
+        'headers' => ['authorization', 'cookie' /* , ... */],
+    ],
+];
+```
+
+## Guard
+
+`guard` pins the authentication guard used to resolve the user a logged request is
+attributed to (e.g. `'sanctum'`). When `null`, the request's default guard is used —
+the one set by the `auth` middleware, or the application's default guard.
+
+## Redaction
+
+The `redact` options control which values are stripped from a log before it is
+stored — see [Redaction](redaction.md) for the defaults and how the matching works.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,6 @@
+---
+title: v3
+slogan: Log the requests made to your Laravel API — who called, what they sent, and what came back
+githubUrl: https://github.com/CodeTechAgency/laravel-api-logs
+branch: main
+---

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,28 @@
+---
+title: Installation
+weight: 3
+group: Getting started
+---
+
+Add the package to your Laravel application using Composer:
+
+```bash
+composer require codetech/laravel-api-logs
+```
+
+The service provider is registered automatically via package discovery.
+
+Publish and run the migrations:
+
+```bash
+php artisan vendor:publish --provider="CodeTech\ApiLogs\Providers\ApiLogServiceProvider" --tag=migrations
+php artisan migrate
+```
+
+Optionally, publish the configuration file:
+
+```bash
+php artisan vendor:publish --provider="CodeTech\ApiLogs\Providers\ApiLogServiceProvider" --tag=config
+```
+
+See [Configuration](configuration.md) for the available options.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,0 +1,26 @@
+---
+title: Introduction
+weight: 1
+group: Getting started
+---
+
+Laravel API Logs is a lightweight package that records the requests made to your
+Laravel API. Each authenticated request is stored as an `ApiLog` Eloquent model with
+the URL, HTTP method, client IP, request data, request headers, response data, and the
+request duration — and is linked to the user that made it through a polymorphic
+`causer` relation.
+
+- **Log with a single middleware** — append it to your `api` middleware group and
+  every authenticated request gets recorded; see [Logging requests](logging-requests.md).
+- **Attach logs to any model** — the `HasApiLogs` trait gives your `User` (or any
+  other authenticatable model) an `apiLogs` relation to query its history.
+- **Redact sensitive values by default** — passwords, tokens, and sensitive headers
+  are replaced before a log is stored; see [Redaction](redaction.md).
+
+## How it works
+
+The `LogApiRequest` middleware runs after your application handles the request. When
+the request is authenticated, it captures the request and the response, passes both
+through the [redactor](redaction.md), and persists an `ApiLog` entry attributed to the
+authenticated user. Unauthenticated requests pass through untouched — nothing is
+logged for them.

--- a/docs/logging-requests.md
+++ b/docs/logging-requests.md
@@ -1,0 +1,43 @@
+---
+title: Logging requests
+weight: 5
+group: Usage
+---
+
+Add the `HasApiLogs` trait to the model that makes the requests (typically your `User`
+model):
+
+```php
+use CodeTech\ApiLogs\Traits\HasApiLogs;
+
+class User extends Authenticatable
+{
+    use HasApiLogs;
+}
+```
+
+To start logging requests made to your API, append the middleware to the `api`
+middleware group in your `bootstrap/app.php`:
+
+```php
+use CodeTech\ApiLogs\Http\Middleware\LogApiRequest;
+use Illuminate\Foundation\Configuration\Middleware;
+
+return Application::configure(basePath: dirname(__DIR__))
+    // ...
+    ->withMiddleware(function (Middleware $middleware) {
+        $middleware->appendToGroup('api', LogApiRequest::class);
+    })
+    // ...
+    ->create();
+```
+
+Only authenticated requests are logged. Each log stores the URL, HTTP method, client
+IP, request data, request headers, response data and the request duration — with
+[sensitive values redacted](redaction.md) — and is linked to the authenticated user
+through a polymorphic `causer` relation:
+
+```php
+$user->apiLogs; // all ApiLog entries for the user
+$apiLog->causer; // the model that made the request
+```

--- a/docs/logging-requests.md
+++ b/docs/logging-requests.md
@@ -21,6 +21,7 @@ middleware group in your `bootstrap/app.php`:
 
 ```php
 use CodeTech\ApiLogs\Http\Middleware\LogApiRequest;
+use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Middleware;
 
 return Application::configure(basePath: dirname(__DIR__))

--- a/docs/redaction.md
+++ b/docs/redaction.md
@@ -1,0 +1,24 @@
+---
+title: Redaction
+weight: 6
+group: Usage
+---
+
+Sensitive values are **redacted by default** before a log is stored: common credential
+fields (`password`, `token`, `access_token`, …) in the request data, query string and
+response data, and sensitive request headers (`Authorization`, `Cookie`, `X-Api-Key`, …)
+are replaced with `[REDACTED]`.
+
+To customize the redaction lists or the replacement string, [publish the config
+file](configuration.md) and adjust the `redact` options in `config/api-logs.php`:
+
+```php
+'redact' => [
+    'replacement' => '[REDACTED]',
+    'keys' => ['password', 'access_token' /* , ... */],
+    'headers' => ['authorization', 'cookie' /* , ... */],
+],
+```
+
+`keys` are matched case-insensitively and recursively against the request payload,
+query string and response data; `headers` are matched against request header names.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,0 +1,13 @@
+---
+title: Requirements
+weight: 2
+group: Getting started
+---
+
+| Package version                                                          | Laravel      | PHP   | Status         |
+|--------------------------------------------------------------------------|--------------|-------|----------------|
+| 3.x (`main`)                                                             | 11 / 12 / 13 | ≥ 8.2 | Active         |
+| 2.x ([`v2`](https://github.com/CodeTechAgency/laravel-api-logs/tree/v2)) | 7 – 10       | ≥ 7.2 | Security fixes |
+| 1.x ([`v1`](https://github.com/CodeTechAgency/laravel-api-logs/tree/v1)) | 7 – 10       | ≥ 7.2 | End of life    |
+
+Upgrading from an older version? See the [upgrade guide](https://github.com/CodeTechAgency/laravel-api-logs/blob/main/UPGRADE.md).


### PR DESCRIPTION
Closes #34.

Applies the docs convention from [laravel-eupago](https://github.com/CodeTechAgency/laravel-eupago/tree/master/docs) so the codetech.pt website can import this package's documentation as a collection.

## Changes

- New `docs/` folder with 6 content pages plus an `index.md` carrying the site-level config (`title: v3`, slogan, `githubUrl`, `branch: main`).
- Pages carry `title` / `weight` / `group` frontmatter with global weights 1–6 across two sidebar groups:
  - **Getting started** — introduction, requirements, installation, configuration
  - **Usage** — logging-requests, redaction
- README slimmed from 143 to ~90 lines: banner, badges, intro paragraph, a quick start (install, middleware, trait), a Documentation section linking to the hosted docs and the upgrade guide, and the standard meta sections.
- The README's "Testing & code quality" section was dropped — CONTRIBUTING.md already documents the quality suite.

`introduction.md` is the only newly written content (overview + "How it works"); the remaining pages carry the README content over with only linking/phrasing adjustments.