### PR TITLE
docs: split multi-command code blocks into one step per block

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,17 @@ anything hits the database.
 
 ```bash
 composer require codetech/laravel-api-logs
+```
+
+Publish the migrations:
+
+```bash
 php artisan vendor:publish --provider="CodeTech\ApiLogs\Providers\ApiLogServiceProvider" --tag=migrations
+```
+
+Run them:
+
+```bash
 php artisan migrate
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,10 +12,15 @@ composer require codetech/laravel-api-logs
 
 The service provider is registered automatically via package discovery.
 
-Publish and run the migrations:
+Publish the migrations:
 
 ```bash
 php artisan vendor:publish --provider="CodeTech\ApiLogs\Providers\ApiLogServiceProvider" --tag=migrations
+```
+
+Run them:
+
+```bash
 php artisan migrate
 ```
 


### PR DESCRIPTION
Splits the crammed multi-command bash blocks in the README Quick start and docs/installation.md so each command sits in its own block, introduced by a short prose line — matching the style used across our other packages.

Closes #38