### PR TITLE
docs(setup): name the migrations in the run instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Publish the migrations:
 php artisan vendor:publish --provider="CodeTech\ApiLogs\Providers\ApiLogServiceProvider" --tag=migrations
 ```
 
-Run them:
+Run the migrations:
 
 ```bash
 php artisan migrate

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -18,7 +18,7 @@ Publish the migrations:
 php artisan vendor:publish --provider="CodeTech\ApiLogs\Providers\ApiLogServiceProvider" --tag=migrations
 ```
 
-Run them:
+Run the migrations:
 
 ```bash
 php artisan migrate


### PR DESCRIPTION
Closes #42.

Renames the "Run them:" intro above the `php artisan migrate` block to "Run the migrations:", in the README Quick start and in `docs/installation.md`. The explicit noun makes the instruction unambiguous and standalone. Propagated from laravel-eupago, where a Copilot review suggested it (CodeTechAgency/laravel-eupago#85).